### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 一个基于Model Context Protocol (MCP)的浏览器自动化服务器，使用Puppeteer提供强大的网页浏览、内容提取和交互功能。
 
+<a href="https://glama.ai/mcp/servers/@pansin/browserMCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pansin/browserMCP/badge" alt="Browser Server MCP server" />
+</a>
+
 ## 功能特点
 
 - **页面导航**：导航到URL、刷新、前进/后退


### PR DESCRIPTION
This PR adds a badge for the [Browser MCP Server](https://glama.ai/mcp/servers/@pansin/browserMCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pansin/browserMCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pansin/browserMCP/badge" alt="Browser Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.